### PR TITLE
fix previous remaining calculation error

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,7 @@ const mixin = options => {
 								if (info.remaining || info.hasNext || info.hasPrevious) {
 									return this.clone().resultSize().then(rs => {
 										rs = parseInt(rs, 10);
-										const remaining = rs - models.length;
+										const remaining = before ? total - rs : rs - models.length;
 										setIfEnabled('remaining', remaining);
 										setIfEnabled('hasNext', (!before && remaining > 0) || (before && total - rs > 0));
 										setIfEnabled('hasPrevious', (before && remaining > 0) || (!before && total - rs > 0));


### PR DESCRIPTION
when back to previous page, remaining should be `total - rs` rather than `rs - models.length`

**eg**: 
we have 16 records, and we are on the 2nd page(11 - 16)
when click previous btn, `rs` is equal to 10 since we are moving to records(1 - 10), 
and models.length is also 10 which cause remaining equals to 0, 
this happens on sql like `select * from user order by name asc, id asc`
