### PR TITLE
feat(pageInfo): remainingBefore, remainingAfter, hasMore

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,15 @@ class Movie extends cursorMixin(Model) {
 {
   results: // Resulted rows.
   pageInfo: {
-    next: // Provide this in the next `cursorPage` call to fetch items after the last ones.
-    previous: // Provide this in the next `previousCursorPage` call to fetch items before the last ones.
+    next: // Provide this in the next `cursorPage` call to fetch items after current results.
+    previous: // Provide this in the next `previousCursorPage` call to fetch items before current results.
 
     hasNext: // If `options.pageInfo.hasNext` is true.
     hasPrevious: // If `options.pageInfo.hasPrevious` is true.
     remaining: // If `options.pageInfo.remaining` is true. Number of items remaining (after or before `results`).
-    total: // If `options.pageInfo.total` is true. Total number of rows (without limit).
+    remainingBefore: // If `options.pageInfo.remainingBefore` is true. Number of items remaining before `results`.
+    remainingAfter: // If `options.pageInfo.remainingAfter` is true. Number of items remaining after `results`.
+    total: // If `options.pageInfo.total` is true. Total number of available rows (without limit).
   }
 }
 ```
@@ -195,15 +197,25 @@ Values shown are defaults.
     // When true, these values will be added to `pageInfo` in query response
     total: false, // Total amount of rows
     remaining: false, // Remaining amount of rows in *this* direction
+    remainingBefore: false, // Remaining amount of rows before current results
+    remainingAfter: false, // Remaining amount of rows after current results
     hasNext: false, // Are there rows after current results?
     hasPrevious: false, // Are there rows before current results?
   }
 }
 ```
 
-**Notes:**
+### Notes
 
-- `pageInfo.total` requires an additional query.
-- `pageInfo.remaining` requires and additional query.
-- `pageInfo.hasNext` requires the same queries as `pageInfo.total` and `pageInfo.remaining`.
-- `pageInfo.hasPrevious` requires the same queries as `pageInfo.total` and `pageInfo.remaining`.
+- `pageInfo.total` requires additional query (**A**)
+- `pageInfo.remaining` requires additional query (**B**)
+- `pageInfo.remainingBefore` requires additional queries (**A**, **B**)
+- `pageInfo.remainingAfter` requires additional queries (**A**, **B**)
+- `pageInfo.hasNext` requires additional queries (**A**, **B**)
+- `pageInfo.hasPrevious` requires additional queries (**A**, **B**)
+
+**`remaining` vs `remainingBefore` and `remainingAfter`:**
+
+`remaining` only tells you the remaining results in *current* direction and is therefore less descriptive as `remainingBefore` and `remainingAfter` combined. However, in cases where it's enough to know if there are "more" results, using only the `remaining` information will use one less query than using any one of `remainingBefore`, `remainingAfter`, `hasPrevious`, and `hasNext`.
+
+However, if `total` is used, then using `remaining` no longer gives you the benefit of using one less query.

--- a/test/options.js
+++ b/test/options.js
@@ -37,6 +37,57 @@ module.exports = knex => {
 				});
 		});
 
+		it('has remainingBefore', () => {
+			class Movie extends cursorPagination({pageInfo: {remainingBefore: true}})(Model) {
+				static get tableName() {
+					return 'movies';
+				}
+			}
+
+			return Movie
+				.query(knex)
+				.orderBy('id', 'asc')
+				.cursorPage()
+				.limit(10)
+				.then(({pageInfo}) => {
+					expect(pageInfo.remainingBefore).to.equal(0);
+				});
+		});
+
+		it('has remainingAfter', () => {
+			class Movie extends cursorPagination({pageInfo: {remainingAfter: true}})(Model) {
+				static get tableName() {
+					return 'movies';
+				}
+			}
+
+			return Movie
+				.query(knex)
+				.orderBy('id', 'asc')
+				.cursorPage()
+				.limit(10)
+				.then(({pageInfo}) => {
+					expect(pageInfo.remainingAfter).to.equal(10);
+				});
+		});
+
+		it('has hasMore', () => {
+			class Movie extends cursorPagination({pageInfo: {hasMore: true}})(Model) {
+				static get tableName() {
+					return 'movies';
+				}
+			}
+
+			return Movie
+				.query(knex)
+				.orderBy('id', 'asc')
+				.cursorPage()
+				.limit(10)
+				.then(({pageInfo}) => {
+					expect(pageInfo.hasMore).to.equal(true);
+				});
+		});
+
 		it('has hasNext', () => {
 			class Movie extends cursorPagination({pageInfo: {hasNext: true}})(Model) {
 				static get tableName() {

--- a/test/ref.js
+++ b/test/ref.js
@@ -39,14 +39,15 @@ module.exports = knex => {
 			}
 		}
 
+		MovieRef.knex(knex);
 		Movie.knex(knex);
 
 		it('order by ref', () => {
 			const query = Movie
 				.query()
-				.joinEager('ref')
 				.orderByCoalesce(ref('ref.data:none').castText(), 'desc', raw('?', ''))
-				.orderBy('movies.id', 'asc');
+				.orderBy('movies.id', 'asc')
+				.joinEager('ref');
 
 			let expected;
 


### PR DESCRIPTION
### Description

Adds `remainingBefore`, `remainingAfter`, and `hasMore` values to `pageInfo`.

Also some miscellaneous fixes, which make the bulk of the changes here:

- Fix: `cursorPage` no longer has to be last call in query builder chain.
- Fix: `orderByCoalesce` can be used without `cursorPage`

---

Continuation of https://github.com/olavim/objection-cursor/pull/6 by @idododu