### PR TITLE
fix: Dont use `mergeContext` on objection v2, to avoid deprecationg warning

### DIFF
--- a/lib/operations/utils.js
+++ b/lib/operations/utils.js
@@ -2,13 +2,23 @@ const Operation = require('./Operation');
 
 const CTX_OPERATIONS = '__cursor_operations';
 
+function mergeContext(builder, nextContext) {
+	if (typeof builder.clearContext === 'undefined') {
+		// objection v1 (before this commit:
+		// https://github.com/Vincit/objection.js/commit/9c9b25569e99ac3fd26d58791a7720d6d608c074 )
+		return builder.mergeContext(nextContext);
+	} else {
+		return builder.context(nextContext);
+	}
+}
+
 function addOperation(builder, operation, args = []) {
 	if (!operation.onAdd(builder, args)) {
 		return builder;
 	}
 
 	const ops = builder.context()[CTX_OPERATIONS] || [];
-	builder.mergeContext({[CTX_OPERATIONS]: [...ops, operation]});
+	mergeContext(builder, {[CTX_OPERATIONS]: [...ops, operation]});
 
 	if (ops.length > 0) {
 		return builder;
@@ -34,7 +44,7 @@ function getOperations(builder, selector = true, match = true) {
 
 function clearOperations(builder, selector) {
 	const ops = getOperations(builder, selector, false);
-	return builder.mergeContext({[CTX_OPERATIONS]: ops});
+	return mergeContext(builder, {[CTX_OPERATIONS]: ops});
 }
 
 function hasOperation(builder, selector) {
@@ -46,7 +56,7 @@ function cloneOperations(builder) {
 }
 
 function setOperations(builder, operations) {
-	return builder.mergeContext({[CTX_OPERATIONS]: operations});
+	return mergeContext(builder, {[CTX_OPERATIONS]: operations});
 }
 
 function predicateForOperationSelector(selector) {


### PR DESCRIPTION
Fixes olavim/objection-cursor#21 and is backwards compatible.